### PR TITLE
Add simple weather dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# trycodex
+# Weather Dashboard
+
+A simple Flask-based weather dashboard using the free Open-Meteo API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r weather_dashboard/requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   python weather_dashboard/app.py
+   ```
+3. Open `http://localhost:5000` in your browser.
+
+Enter a city name to see the current weather.

--- a/weather_dashboard/app.py
+++ b/weather_dashboard/app.py
@@ -1,0 +1,43 @@
+from flask import Flask, render_template, request
+import requests
+
+app = Flask(__name__)
+
+
+def get_coordinates(city):
+    url = "https://geocoding-api.open-meteo.com/v1/search"
+    params = {"name": city, "count": 1}
+    r = requests.get(url, params=params)
+    data = r.json()
+    results = data.get("results")
+    if results:
+        return results[0]["latitude"], results[0]["longitude"]
+    return None, None
+
+
+def get_weather(lat, lon):
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "current_weather": True
+    }
+    r = requests.get(url, params=params)
+    data = r.json()
+    return data.get("current_weather")
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    weather = None
+    city = None
+    if request.method == 'POST':
+        city = request.form.get('city')
+        lat, lon = get_coordinates(city)
+        if lat and lon:
+            weather = get_weather(lat, lon)
+    return render_template('index.html', weather=weather, city=city)
+
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/weather_dashboard/requirements.txt
+++ b/weather_dashboard/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/weather_dashboard/static/style.css
+++ b/weather_dashboard/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+form { margin-bottom: 1em; }

--- a/weather_dashboard/templates/index.html
+++ b/weather_dashboard/templates/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Weather Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Weather Dashboard</h1>
+    <form method="post">
+        <input type="text" name="city" placeholder="Enter city" required>
+        <button type="submit">Get Weather</button>
+    </form>
+    {% if weather %}
+    <h2>Weather for {{ city }}</h2>
+    <p>Temperature: {{ weather.temperature }} °C</p>
+    <p>Wind Speed: {{ weather.windspeed }} km/h</p>
+    <p>Condition: {{ weather.weathercode }}</p>
+    {% elif city %}
+    <p>Could not fetch weather for {{ city }}.</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Flask weather dashboard using the free Open-Meteo API
- document setup steps for running the dashboard

## Testing
- `pip install -r weather_dashboard/requirements.txt`
- `python weather_dashboard/app.py` *(started server successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68779496f9c08326accc95d2c4684603